### PR TITLE
fix(u-boot-marvell_2013.01): set build directory to the same as source directory again

### DIFF
--- a/recipes-bsp/u-boot/u-boot-marvell_2013.01.bb
+++ b/recipes-bsp/u-boot/u-boot-marvell_2013.01.bb
@@ -24,6 +24,7 @@ SRCREV_FORMAT = "uboot"
 PV .= "+git${SRCPV}"
 
 S = "${WORKDIR}/uboot"
+B = "${S}"
 
 do_compile () {
     unset LDFLAGS

--- a/recipes-bsp/u-boot/u-boot-script-marvell_2013.01.bb
+++ b/recipes-bsp/u-boot/u-boot-script-marvell_2013.01.bb
@@ -14,7 +14,7 @@ FILES_${PN} += "/boot.scr"
 
 do_mkimage () {
     uboot-mkimage -A arm -O linux -T script -C none -a 0 -e 0 \
-                  -n "boot script" -d ${BOOTSCRIPT} boot.scr
+                  -n "boot script" -d ${BOOTSCRIPT} ${S}/boot.scr
 }
 
 addtask mkimage after do_compile before do_install


### PR DESCRIPTION
Greetings everyone, 

I had some issues with the changed source directory, build.pl couldn't be found. I changed the build directory to the newly assigned source directory. I am by far no expert with bitbake but hope the patch makes sense.

Cheers!
Robert